### PR TITLE
Avoid showing invisible text

### DIFF
--- a/addon/styles/_fonts.scss
+++ b/addon/styles/_fonts.scss
@@ -3,34 +3,40 @@
   font-style: normal;
   font-weight: 400;
   src: local('Cardo'), local('Cardo-Regular'), url('//fonts.gstatic.com/s/cardo/v8/f9GbO0_LnwwuaRC6yAh0JKCWcynf_cDxXwCLxiixG1c.woff2') format('woff2'), url('//fonts.gstatic.com/s/cardo/v8/c6Zi_ulq7hv-avk-G9Yut6CWcynf_cDxXwCLxiixG1c.woff') format('woff');
+  font-display: swap;
 }
 @font-face {
   font-family: 'Cardo';
   font-style: normal;
   font-weight: 700;
   src: local('Cardo Bold'), local('Cardo-Bold'), url('//fonts.gstatic.com/s/cardo/v8/X-1BEHTKpRYzad3JEXy9-nYhjbSpvc47ee6xR_80Hnw.woff2') format('woff2'), url('//fonts.gstatic.com/s/cardo/v8/gHC1KgRPdVNdvvVcxLMCY3YhjbSpvc47ee6xR_80Hnw.woff') format('woff');
+  font-display: swap;
 }
 @font-face {
   font-family: 'Cardo';
   font-style: italic;
   font-weight: 400;
   src: local('Cardo Italic'), local('Cardo-Italic'), url('//fonts.gstatic.com/s/cardo/v8/aRpKelDgx13ov6asvC3QbgLUuEpTyoUstqEm5AMlJo4.woff2') format('woff2'), url('//fonts.gstatic.com/s/cardo/v8/mSKSxAIybPTfRoik7xAeTQLUuEpTyoUstqEm5AMlJo4.woff') format('woff');
+  font-display: swap;
 }
 @font-face {
   font-family: 'Fira Sans';
   font-style: normal;
   font-weight: 400;
   src: local('Fira Sans'), local('FiraSans-Regular'), url('//fonts.gstatic.com/s/firasans/v5/EjsrzDkQUQCDwsBtLpcVQZBw1xU1rKptJj_0jans920.woff2') format('woff2'), url('//fonts.gstatic.com/s/firasans/v5/EjsrzDkQUQCDwsBtLpcVQbO3LdcAZYWl9Si6vvxL-qU.woff') format('woff');
+  font-display: swap;
 }
 @font-face {
   font-family: 'Fira Sans';
   font-style: normal;
   font-weight: 500;
   src: local('Fira Sans Medium'), local('FiraSans-Medium'), url('//fonts.gstatic.com/s/firasans/v5/zM2u8V3CuPVwAAXFQcDi4Bampu5_7CjHW5spxoeN3Vs.woff2') format('woff2'), url('//fonts.gstatic.com/s/firasans/v5/zM2u8V3CuPVwAAXFQcDi4KRDOzjiPcYnFooOUGCOsRk.woff') format('woff');
+  font-display: swap;
 }
 @font-face {
   font-family: 'Fira Sans';
   font-style: normal;
   font-weight: 700;
   src: local('Fira Sans Bold'), local('FiraSans-Bold'), url('//fonts.gstatic.com/s/firasans/v5/DugPdSljmOTocZOR2CItOhampu5_7CjHW5spxoeN3Vs.woff2') format('woff2'), url('//fonts.gstatic.com/s/firasans/v5/DugPdSljmOTocZOR2CItOqRDOzjiPcYnFooOUGCOsRk.woff') format('woff');
+  font-display: swap;
 }


### PR DESCRIPTION
Small change to avoid showing invisible text while the fonts are being loaded and get a better lighthouse score.

https://web.dev/font-display/?utm_source=lighthouse&utm_medium=devtools